### PR TITLE
Fix PruneCluster spiderify bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
 
           });
         m.setOpacity = L.Util.falseFn; // a fake setOpacity method#
+        m.setZIndexOffset = L.Util.falseFn;
         this.PrepareLeafletMarker(m, marker.data, marker.category);
         return m;
       }


### PR DESCRIPTION
Fixes error when 2 markers have the same coordinates and the users click on the cluster symbol.